### PR TITLE
feat: support customizable image models and local reference upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@
 
 ## 核心功能
 
-- ✅ **文生图** - 通过文本描述生成高质量图像 (模型: jimeng_t2i_s20pro)
-- ✅ **文生视频** - 将文本描述转换为流畅视频 (模型: jimeng_vgfm_t2v_l20)
-- ✅ **图生视频** - 将静态图像转换为动态视频 (模型: jimeng_vgfm_i2v_l20)
+- ✅ **文生图** - 通过文本描述生成高质量图像 (模型: jimeng_t2i_v40)
+- ✅ **文生视频** - 将文本描述转换为流畅视频 (模型: jimeng_vgfm_t2v_l22)
+- ✅ **图生视频** - 将静态图像转换为动态视频 (模型: jimeng_vgfm_i2v_l22)
 - ✅ **多平台支持** - 支持 macOS、Linux、Windows 及 WSL 环境
 - 🛠️ 完整TypeScript类型定义和错误处理
 - 🔄 支持异步任务处理和状态追踪
@@ -441,11 +441,29 @@ npm publish
 - `text`: 要在图片上显示的文字
 - `illustration`: 作为图片配饰的插画元素关键词
 - `color`: 图片的背景主色调
-- `ratio`: 图片比例，支持: 4:3 (512×384), 3:4 (384×512), 16:9 (512×288), 9:16 (288×512)
+- `ratio`: 图片比例，支持: 4:3 (2304×1728), 3:4 (1728×2304), 16:9 (2560×1440), 9:16 (1440×2560)
+- `model` *(可选)*: 指定文生图模型 `req_key`，默认 `jimeng_t2i_v40`
 
 **示例**：
 ```
 请使用generate-image工具生成一张图片，图片上显示"创新未来"文字，配饰元素包括科技、星空、光线，背景色调为蓝色，比例为16:9。
+```
+
+### image-to-image
+
+基于参考图片生成变体或进行局部编辑。
+
+**参数**：
+- `prompt`: 目标图像的描述
+- `references`: 参考图片列表，支持 HTTP(S) URL 或绝对本地路径，至少一项
+- `model` *(可选)*: 指定图生图模型 `req_key`，默认 `jimeng_t2i_v40`
+- `width` / `height` *(可选)*: 指定输出宽高 (像素)
+- `size` *(可选)*: 指定输出面积 (像素平方)
+- `return_url` *(可选)*: 是否返回图片 URL，默认 `true`
+
+**示例**：
+```
+请使用image-to-image工具，根据参考图"/data/refs/hero.png"和"https://example.com/pose.jpg"，生成提示词为"未来派机甲角色"的图像。
 ```
 
 ### generate-video
@@ -489,7 +507,7 @@ import { JimengClient } from 'jimeng-ai-mcp';
 const client = new JimengClient({
   accessKey: 'YOUR_ACCESS_KEY',
   secretKey: 'YOUR_SECRET_KEY',
-  region: 'cn-beijing', // 默认区域
+  region: 'cn-north-1', // 默认区域
   debug: false // 设置为true可以查看详细日志
 });
 
@@ -497,12 +515,34 @@ const client = new JimengClient({
 async function generateImage() {
   const result = await client.generateImage({
     prompt: "一只可爱的猫咪在草地上玩耍",
-    width: 512,
-    height: 512
+    width: 2048,
+    height: 2048,
+    force_single: true
   });
   
   if (result.success && result.image_urls && result.image_urls.length > 0) {
     console.log('图像URL:', result.image_urls[0]);
+    console.log('任务ID:', result.task_id);
+    console.log('最终状态:', result.status);
+  } else {
+    console.error('生成失败:', result.error);
+  }
+}
+
+// 图生图示例（自动上传本地参考图）
+async function generateImageWithReferences() {
+  const result = await client.generateImage({
+    prompt: "复古科幻风格的人像",
+    image_paths: ["/absolute/path/to/reference.png"],
+    image_urls: ["https://example.com/pose.jpg"],
+    req_key: "jimeng_t2i_v40",
+    width: 2048,
+    height: 2048,
+    return_url: true
+  });
+
+  if (result.success && result.image_urls?.length) {
+    console.log('图像URL:', result.image_urls);
   } else {
     console.error('生成失败:', result.error);
   }
@@ -537,35 +577,98 @@ async function generateImageToVideo() {
 }
 ```
 
+> 提示：即梦AI 图片生成4.0 接口支持 `force_single`、`size`、`width`/`height`、`min_ratio`/`max_ratio`、`scale` 等高级参数，可根据业务场景控制输出数量、分辨率和比例。本项目默认使用 `force_single: true` 并请求 2K 分辨率，以便快速得到稳定的单张结果。命令行示例支持第 5 个参数传入水印文案，并可通过 `--model <req_key>`（或第 6 个位置参数）指定自定义模型，例如：
+>
+> ```bash
+> npx ts-node examples/jimeng-image-generator.ts "一只可爱的猫咪" 2048 2048 "这里是明水印内容" --model jimeng_t2i_v40
+> ```
+>
+> 图生图示例脚本会自动上传本地绝对路径参考图：
+>
+> ```bash
+> npx ts-node examples/jimeng-image-to-image.ts "未来派机甲角色" /data/refs/hero.png https://example.com/pose.jpg --width 2048 --height 2048
+> ```
+
 ### 高级用法：异步任务处理
 
-对于耗时较长的视频生成任务，可以使用异步方式：
+即梦AI 图片生成4.0 和视频生成接口都使用异步任务模式。可以分别使用 `submitImageTask`/`getImageTaskResult` 与视频相关的任务接口进行轮询：
 
 ```typescript
-// 文生视频异步方式
-async function generateVideoAsync() {
-  // 提交任务
-  const taskResult = await client.submitVideoTask({
+// 文生图异步方式（jimeng_t2i_v40）
+async function generateImageAsync() {
+  const taskResult = await client.submitImageTask({
     prompt: "一只可爱的猫咪在草地上玩耍",
-    req_key: "jimeng_vgfm_t2v_l20"
+    width: 2048,
+    height: 2048,
+    force_single: true
   });
-  
-  console.log('任务ID:', taskResult.task_id);
-  
-  // 轮询任务结果
+
+  if (!taskResult.success || !taskResult.task_id) {
+    console.error('提交失败:', taskResult.error);
+    return;
+  }
+
+  console.log('图像任务ID:', taskResult.task_id);
+
   let result;
   do {
-    // 等待60秒再查询（符合API限制）
-    await new Promise(resolve => setTimeout(resolve, 60000));
-    
-    // 查询任务结果
-    result = await client.getVideoTaskResult(taskResult.task_id);
+    await new Promise(resolve => setTimeout(resolve, 5000));
+    result = await client.getImageTaskResult(taskResult.task_id, { return_url: true });
     console.log('任务状态:', result.status);
-    
+  } while (result.status === 'IN_QUEUE' || result.status === 'GENERATING');
+
+  if (result.success && result.status === 'DONE' && result.image_urls?.length) {
+    console.log('图像URL:', result.image_urls);
+  } else {
+    console.error('生成失败:', result.error);
+  }
+}
+
+// 查询结果时透传水印参数
+async function getResultWithWatermark(taskId: string) {
+  const result = await client.getImageTaskResult(taskId, {
+    logo_info: {
+      add_logo: true,
+      position: 0,
+      language: 0,
+      opacity: 1,
+      logo_text_content: '这里是明水印内容'
+    },
+    return_url: true
+  });
+
+  if (result.success && result.status === 'DONE') {
+    console.log('带水印的图像 URL:', result.image_urls);
+  }
+}
+
+// 文生视频异步方式
+async function generateVideoAsync() {
+  const taskResult = await client.submitVideoTask({
+    prompt: "一只可爱的猫咪在草地上玩耍",
+    req_key: "jimeng_vgfm_t2v_l22",
+    duration: 8,
+    aspect_ratio: "16:9",
+    return_url: true,
+    return_video_base64: false
+  });
+
+  console.log('视频任务ID:', taskResult.task_id);
+
+  let result;
+  do {
+    await new Promise(resolve => setTimeout(resolve, 60000));
+    result = await client.getVideoTaskResult(taskResult.task_id, "jimeng_vgfm_t2v_l22", {
+      extra_body: { return_url: true }
+    });
+    console.log('任务状态:', result.status);
   } while (result.status === 'PENDING' || result.status === 'RUNNING');
-  
+
   if (result.success && result.status === 'SUCCEEDED') {
     console.log('视频URL:', result.video_urls);
+    if (result.video_base64_list?.length) {
+      console.log('返回的 Base64 视频数量:', result.video_base64_list.length);
+    }
   } else {
     console.error('生成失败:', result.error);
   }
@@ -573,20 +676,25 @@ async function generateVideoAsync() {
 
 // 图生视频异步方式
 async function generateImageToVideoAsync() {
-  // 提交任务
   const taskResult = await client.submitI2VTask({
     image_urls: ["https://example.com/image.jpg"],
     prompt: "波浪效果",
-    req_key: "jimeng_vgfm_i2v_l20"
+    req_key: "jimeng_vgfm_i2v_l22",
+    aspect_ratio: "21:9",
+    return_url: true
   });
-  
-  console.log('任务ID:', taskResult.task_id);
-  
-  // 查询任务结果（简化示例，实际应用需要轮询）
-  const result = await client.getVideoTaskResult(taskResult.task_id, "jimeng_vgfm_i2v_l20");
-  
+
+  console.log('图生视频任务ID:', taskResult.task_id);
+
+  const result = await client.getVideoTaskResult(taskResult.task_id, "jimeng_vgfm_i2v_l22", {
+    extra_body: { return_url: true }
+  });
+
   if (result.success && result.status === 'SUCCEEDED') {
     console.log('视频URL:', result.video_urls);
+    if (result.video_base64_list?.length) {
+      console.log('返回的 Base64 视频数量:', result.video_base64_list.length);
+    }
   }
 }
 ```
@@ -688,10 +796,10 @@ MIT
 ```
 
 支持的图片比例：
-- `4:3` - 512×384像素
-- `3:4` - 384×512像素
-- `16:9` - 512×288像素
-- `9:16` - 288×512像素
+- `4:3` - 2304×1728像素
+- `3:4` - 1728×2304像素
+- `16:9` - 2560×1440像素
+- `9:16` - 1440×2560像素
 
 ### 视频生成 (generate-video)
 
@@ -702,6 +810,10 @@ MIT
 - `prompt` - 视频内容描述（必填）
 - `async` - 是否使用异步方式（可选，默认为`true`）
 - `intent_sync` - 是否检测到同步生成意图（可选，默认为`false`）
+- `duration` - 视频时长（秒，可选，默认由模型自动决定）
+- `aspect_ratio` - 视频宽高比（例如`16:9`、`21:9`，可选）
+- `return_url` - 是否返回结果中的临时下载链接（可选，默认`false`）
+- `return_video_base64` - 是否返回视频Base64数据（可选，默认`false`）
 
 #### 行为模式
 
@@ -710,11 +822,12 @@ MIT
    - 需要后续使用`get-video-task`工具查询结果
    - 适合生产环境和避免超时的场景
 
-   ```json
-   {
-     "prompt": "一只熊猫在竹林中玩耍"
-   }
-   ```
+  ```json
+  {
+    "prompt": "一只熊猫在竹林中玩耍",
+    "return_url": true
+  }
+  ```
 
 2. **同步模式**：
    - 等待视频生成完成后返回结果（可能需要1-2分钟）
@@ -726,12 +839,13 @@ MIT
    - 设置`intent_sync=true`
    - 在提示中包含表示期望即时结果的关键词（如"一次输出"、"同步输出"、"等待结果"等）
 
-   ```json
-   {
-     "prompt": "一只熊猫在竹林中玩耍",
-     "async": false
-   }
-   ```
+  ```json
+  {
+    "prompt": "一只熊猫在竹林中玩耍",
+    "async": false,
+    "duration": 10
+  }
+  ```
 
    或通过意图表达（大模型会自动识别并设置`intent_sync=true`）：
    
@@ -754,7 +868,9 @@ MIT
 ```json
 // submit-video-task
 {
-  "prompt": "一只白色的小猪在沙滩上跑动"
+  "prompt": "一只白色的小猪在沙滩上跑动",
+  "req_key": "jimeng_vgfm_t2v_l22",
+  "return_url": true
 }
 ```
 
@@ -763,6 +879,7 @@ MIT
 ```json
 // get-video-task
 {
-  "task_id": "12345678901234567890"
+  "task_id": "12345678901234567890",
+  "return_url": true
 }
-``` 
+```

--- a/examples/jimeng-image-to-image.ts
+++ b/examples/jimeng-image-to-image.ts
@@ -1,0 +1,194 @@
+/**
+ * 即梦AI 图生图示例脚本
+ *
+ * 使用方法:
+ *   npx ts-node examples/jimeng-image-to-image.ts "提示词" /abs/path/reference.png [更多参考图]
+ *
+ * 可选参数:
+ *   --model <req_key>     指定模型，例如 jimeng_t2i_v40
+ *   --width <value>       输出宽度
+ *   --height <value>      输出高度
+ *   --size <value>        输出面积，单位像素^2
+ *   --region <value>      指定区域，默认为 cn-north-1
+ *   --no-return-url       仅返回 Base64，关闭 URL 输出
+ */
+
+import { JimengClient } from '../src';
+import * as dotenv from 'dotenv';
+import * as fs from 'fs';
+import * as path from 'path';
+
+dotenv.config();
+
+const rawArgs = process.argv.slice(2);
+const positionalArgs: string[] = [];
+let modelKey: string | undefined;
+let widthValue: number | undefined;
+let heightValue: number | undefined;
+let sizeValue: number | undefined;
+let region = 'cn-north-1';
+let returnUrl = true;
+
+for (let i = 0; i < rawArgs.length; i++) {
+  const arg = rawArgs[i];
+
+  if (arg === '--model' && i + 1 < rawArgs.length) {
+    modelKey = rawArgs[++i];
+    continue;
+  }
+  if (arg.startsWith('--model=')) {
+    modelKey = arg.substring('--model='.length);
+    continue;
+  }
+
+  if (arg === '--width' && i + 1 < rawArgs.length) {
+    widthValue = parseInt(rawArgs[++i], 10);
+    continue;
+  }
+  if (arg.startsWith('--width=')) {
+    widthValue = parseInt(arg.substring('--width='.length), 10);
+    continue;
+  }
+
+  if (arg === '--height' && i + 1 < rawArgs.length) {
+    heightValue = parseInt(rawArgs[++i], 10);
+    continue;
+  }
+  if (arg.startsWith('--height=')) {
+    heightValue = parseInt(arg.substring('--height='.length), 10);
+    continue;
+  }
+
+  if (arg === '--size' && i + 1 < rawArgs.length) {
+    sizeValue = parseInt(rawArgs[++i], 10);
+    continue;
+  }
+  if (arg.startsWith('--size=')) {
+    sizeValue = parseInt(arg.substring('--size='.length), 10);
+    continue;
+  }
+
+  if (arg === '--region' && i + 1 < rawArgs.length) {
+    region = rawArgs[++i];
+    continue;
+  }
+  if (arg.startsWith('--region=')) {
+    region = arg.substring('--region='.length);
+    continue;
+  }
+
+  if (arg === '--no-return-url') {
+    returnUrl = false;
+    continue;
+  }
+
+  positionalArgs.push(arg);
+}
+
+const prompt = positionalArgs.shift();
+const referenceInputs = positionalArgs;
+
+if (!prompt) {
+  console.error('错误: 需要提供提示词，例如 "修复参考图"');
+  process.exit(1);
+}
+
+if (referenceInputs.length === 0) {
+  console.error('错误: 需要至少提供一张参考图片 (本地绝对路径或URL)');
+  process.exit(1);
+}
+
+if (!process.env.JIMENG_ACCESS_KEY || !process.env.JIMENG_SECRET_KEY) {
+  console.error('错误: 需要设置环境变量 JIMENG_ACCESS_KEY 和 JIMENG_SECRET_KEY');
+  process.exit(1);
+}
+
+const localReferences: string[] = [];
+const remoteReferences: string[] = [];
+
+for (const item of referenceInputs) {
+  if (/^https?:\/\//i.test(item)) {
+    remoteReferences.push(item);
+  } else {
+    const resolved = path.isAbsolute(item) ? item : path.resolve(process.cwd(), item);
+    if (!fs.existsSync(resolved)) {
+      console.error(`错误: 本地图片不存在 -> ${resolved}`);
+      process.exit(1);
+    }
+    localReferences.push(resolved);
+  }
+}
+
+(async () => {
+  try {
+    console.log('即梦AI 图生图示例');
+    console.log('-------------------');
+    console.log('提示词:', prompt);
+    console.log('模型:', modelKey || 'jimeng_t2i_v40 (默认)');
+    console.log('区域:', region);
+    if (typeof widthValue === 'number' && typeof heightValue === 'number') {
+      console.log('输出尺寸:', `${widthValue}x${heightValue}`);
+    } else if (typeof sizeValue === 'number') {
+      console.log('输出面积:', sizeValue);
+    }
+    console.log('参考图数量:', referenceInputs.length);
+    if (localReferences.length > 0) {
+      console.log('本地参考图:');
+      localReferences.forEach((item, index) => {
+        console.log(`  [${index + 1}] ${item}`);
+      });
+    }
+    if (remoteReferences.length > 0) {
+      console.log('远程参考图:');
+      remoteReferences.forEach((item, index) => {
+        console.log(`  [${index + 1}] ${item}`);
+      });
+    }
+
+    const client = new JimengClient({ debug: true });
+
+    const startTime = Date.now();
+    const result = await client.generateImage({
+      prompt,
+      req_key: modelKey,
+      width: widthValue,
+      height: heightValue,
+      size: sizeValue,
+      region,
+      return_url: returnUrl,
+      image_urls: remoteReferences.length > 0 ? remoteReferences : undefined,
+      image_paths: localReferences.length > 0 ? localReferences : undefined,
+      force_single: false
+    });
+    const endTime = Date.now();
+
+    console.log(`生成耗时: ${(endTime - startTime) / 1000}秒`);
+
+    if (!result.success) {
+      console.error('生成失败:', result.error || '未知错误');
+      process.exit(1);
+    }
+
+    if (result.image_urls && result.image_urls.length > 0) {
+      console.log('生成图像 URL:');
+      result.image_urls.forEach((url, index) => {
+        console.log(`  [${index + 1}] ${url}`);
+      });
+    }
+
+    if (result.binary_data_base64 && result.binary_data_base64.length > 0) {
+      console.log('生成图像 Base64 列表:');
+      result.binary_data_base64.forEach((item, index) => {
+        console.log(`  [${index + 1}] 长度 ${item.length}`);
+      });
+    }
+
+    if (result.raw_response) {
+      console.log('原始响应片段:');
+      console.log(JSON.stringify(result.raw_response, null, 2));
+    }
+  } catch (error) {
+    console.error('发生异常:', error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+})();

--- a/examples/mcp-server.ts
+++ b/examples/mcp-server.ts
@@ -46,10 +46,10 @@ if (!JIMENG_ACCESS_KEY || !JIMENG_SECRET_KEY) {
 
 // 图片比例映射
 const RATIO_MAPPING: Record<string, { width: number; height: number }> = {
-  "4:3": { width: 512, height: 384 },
-  "3:4": { width: 384, height: 512 }, 
-  "16:9": { width: 512, height: 288 },
-  "9:16": { width: 288, height: 512 }
+  "4:3": { width: 2304, height: 1728 },
+  "3:4": { width: 1728, height: 2304 },
+  "16:9": { width: 2560, height: 1440 },
+  "9:16": { width: 1440, height: 2560 }
 };
 
 // 生成组合后的prompt
@@ -82,7 +82,18 @@ server.resource(
   async (uri) => ({
     contents: [{
       uri: uri.href,
-      text: `# generate-image 工具使用帮助\n\n生成图像的工具，可以根据文字、插图元素和颜色生成图像。\n\n## 参数\n\n- text: 用户需要在图片上显示的文字\n- illustration: 根据用户要显示的文字，提取3-5个可以作为图片配饰的插画元素关键词\n- color: 图片的背景主色调\n- ratio: 图片比例。支持: 4:3 (512*384), 3:4 (384*512), 16:9 (512*288), 9:16 (288*512)\n\n## 示例\n\n请使用generate-image工具生成一张图片，图片上显示"创新未来"文字，配饰元素包括科技、星空、光线，背景色调为蓝色，比例为16:9。`
+      text: `# generate-image 工具使用帮助\n\n生成图像的工具，可以根据文字、插图元素和颜色生成图像。\n\n## 参数\n\n- text: 用户需要在图片上显示的文字\n- illustration: 根据用户要显示的文字，提取3-5个可以作为图片配饰的插画元素关键词\n- color: 图片的背景主色调\n- ratio: 图片比例。支持: 4:3 (2304*1728), 3:4 (1728*2304), 16:9 (2560*1440), 9:16 (1440*2560)\n- model: (可选) 指定即梦文生图模型 req_key，默认使用 jimeng_t2i_v40\n\n## 示例\n\n请使用generate-image工具生成一张图片，图片上显示"创新未来"文字，配饰元素包括科技、星空、光线，背景色调为蓝色，比例为16:9。`
+    }]
+  })
+);
+
+server.resource(
+  "help",
+  "help://image-to-image",
+  async (uri) => ({
+    contents: [{
+      uri: uri.href,
+      text: `# image-to-image 工具使用帮助\n\n基于参考图片进行编辑或生成变体的工具。\n\n## 参数\n\n- prompt: 期望的图像效果描述\n- references: 参考图片URL或绝对本地路径列表，至少一项\n- model: (可选) 指定即梦文生图模型 req_key，默认 jimeng_t2i_v40\n- width/height: (可选) 输出宽高，像素\n- size: (可选) 输出面积，像素平方\n- return_url: (可选) 是否返回图像URL，默认 true\n\n## 示例\n\n请使用image-to-image工具，根据参考图"/home/user/refs/hero.png"和"https://example.com/pose.jpg"，生成提示词为"未来派机甲角色"的图像，并返回图像链接。`
     }]
   })
 );
@@ -94,7 +105,7 @@ server.resource(
   async (uri) => ({
     contents: [{
       uri: uri.href,
-      text: `# generate-video 工具使用帮助\n\n生成视频的工具，使用即梦AI文生视频模型根据文字提示词生成视频。\n\n## 参数\n\n- prompt: 视频内容的描述\n- async: 是否异步生成视频，true表示立即返回任务ID，false表示等待视频生成完成（默认值：true）\n- intent_sync: 是否检测到同步生成意图，如用户提到"一次输出"、"同步输出"、"等待结果"等（默认值：false）\n\n## 行为说明\n\n默认情况下，该工具采用异步方式生成视频，即立即返回任务ID，然后用户需要使用get-video-task工具查询结果。\n\n如果满足以下任一条件，工具将使用同步方式（等待视频生成完成）：\n- 设置async=false\n- 设置intent_sync=true\n- 在提示中包含"一次输出"、"同步输出"、"等待结果"等表示期望即时获取结果的词语\n\n## 注意\n\n- 使用模型：jimeng_vgfm_t2v_l20\n- 视频生成耗时较长(1-2分钟)，若使用同步方式可能遇到超时错误\n- 推荐使用默认的异步方式，避免长时间等待和可能的超时\n\n## 示例\n\n异步方式（推荐）：\n请使用generate-video工具生成一段视频，视频内容为"熊猫在竹林中玩耍"\n\n同步方式：\n请使用generate-video工具生成一段视频，视频内容为"熊猫在竹林中玩耍"，我想一次输出结果`
+      text: `# generate-video 工具使用帮助\n\n生成视频的工具，使用即梦AI文生视频模型根据文字提示词生成视频。\n\n## 参数\n\n- prompt: 视频内容的描述\n- async: 是否异步生成视频，true表示立即返回任务ID，false表示等待视频生成完成（默认值：true）\n- intent_sync: 是否检测到同步生成意图，如用户提到"一次输出"、"同步输出"、"等待结果"等（默认值：false）\n- duration: 可选，指定视频时长（秒）\n- aspect_ratio: 可选，输出宽高比，例如"16:9"、"21:9"\n- return_url: 可选，是否返回临时的下载链接，默认false\n- return_video_base64: 可选，是否返回视频Base64数据，默认false\n\n## 行为说明\n\n默认情况下，该工具采用异步方式生成视频，即立即返回任务ID，然后用户需要使用get-video-task工具查询结果。\n\n如果满足以下任一条件，工具将使用同步方式（等待视频生成完成）：\n- 设置async=false\n- 设置intent_sync=true\n- 在提示中包含"一次输出"、"同步输出"、"等待结果"等表示期望即时获取结果的词语\n\n## 注意\n\n- 使用模型：jimeng_vgfm_t2v_l22\n- 视频生成耗时较长(1-2分钟)，若使用同步方式可能遇到超时错误\n- 推荐使用默认的异步方式，避免长时间等待和可能的超时\n\n## 示例\n\n异步方式（推荐）：\n请使用generate-video工具生成一段视频，视频内容为"熊猫在竹林中玩耍"，并返回下载链接\n\n同步方式：\n请使用generate-video工具生成一段视频，视频内容为"熊猫在竹林中玩耍"，我想一次输出结果`
     }]
   })
 );
@@ -131,10 +142,11 @@ server.tool(
     text: z.string().describe("用户需要在图片上显示的文字"),
     illustration: z.string().describe("根据用户要显示的文字，提取3-5个可以作为图片配饰的插画元素关键词"),
     color: z.string().describe("图片的背景主色调"),
-    ratio: z.enum(["4:3", "3:4", "16:9", "9:16"]).describe("图片比例。支持: 4:3 (512*384), 3:4 (384*512), 16:9 (512*288), 9:16 (288*512)")
+    ratio: z.enum(["4:3", "3:4", "16:9", "9:16"]).describe("图片比例。支持: 4:3 (2304*1728), 3:4 (1728*2304), 16:9 (2560*1440), 9:16 (1440*2560)"),
+    model: z.string().optional().describe("可选模型req_key，默认使用 jimeng_t2i_v40")
   },
   async (args, _extra) => {
-    const { text, illustration, color, ratio } = args;
+    const { text, illustration, color, ratio, model } = args;
     const imageSize = RATIO_MAPPING[ratio];
     
     if (!imageSize) {
@@ -194,7 +206,9 @@ server.tool(
         prompt: prompt,
         width: imageSize.width,
         height: imageSize.height,
-        region: "cn-north-1"
+        force_single: true,
+        region: "cn-north-1",
+        req_key: model
       });
 
       if (!result.success || !result.image_urls || result.image_urls.length === 0) {
@@ -203,6 +217,8 @@ server.tool(
           status: "error",
           message: "生成图片失败",
           error: result.error || "未知错误",
+          task_id: result.task_id,
+          status_detail: result.status,
           timestamp: new Date().toISOString()
         };
         
@@ -232,8 +248,11 @@ server.tool(
           dimensions: `${imageSize.width}×${imageSize.height}`,
           prompt,
           llm_prompt: llmPrompt,
+          model: model || 'jimeng_t2i_v40',
           image_url: result.image_urls[0],
-          image_urls: result.image_urls
+          image_urls: result.image_urls,
+          task_id: result.task_id,
+          status_detail: result.status
         },
         timestamp: new Date().toISOString()
       };
@@ -255,6 +274,157 @@ server.tool(
         timestamp: new Date().toISOString()
       };
       
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(errorData, null, 2)
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// 图生图工具
+server.tool(
+  "image-to-image",
+  "当用户提供参考图像进行编辑或生成变体时使用的工具",
+  {
+    prompt: z.string().describe("生成图像的核心需求描述"),
+    references: z.array(z.string()).min(1).describe("参考图片URL或绝对本地路径，可多张"),
+    model: z.string().optional().describe("可选模型req_key，默认使用 jimeng_t2i_v40"),
+    width: z.number().int().positive().optional().describe("输出宽度，单位像素"),
+    height: z.number().int().positive().optional().describe("输出高度，单位像素"),
+    size: z.number().int().positive().optional().describe("输出面积，单位像素^2"),
+    return_url: z.boolean().optional().describe("是否返回图片URL，默认true"),
+  },
+  async (args) => {
+    if (!JIMENG_ACCESS_KEY || !JIMENG_SECRET_KEY) {
+      const errorData = {
+        status: "error",
+        message: "API密钥未配置",
+        error: "未设置环境变量 JIMENG_ACCESS_KEY 和 JIMENG_SECRET_KEY",
+        help: "请参考文档配置环境变量",
+        timestamp: new Date().toISOString()
+      };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(errorData, null, 2)
+          }
+        ],
+        isError: true
+      };
+    }
+
+    const { prompt, references, model, width, height, size, return_url } = args;
+
+    const remoteReferences: string[] = [];
+    const localReferences: string[] = [];
+
+    for (const ref of references) {
+      if (/^https?:\/\//i.test(ref)) {
+        remoteReferences.push(ref);
+      } else {
+        const resolved = path.isAbsolute(ref) ? ref : path.resolve(process.cwd(), ref);
+        if (!fs.existsSync(resolved)) {
+          const errorData = {
+            status: "error",
+            message: "参考图片不存在",
+            error: `本地路径未找到: ${resolved}`,
+            timestamp: new Date().toISOString()
+          };
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(errorData, null, 2)
+              }
+            ],
+            isError: true
+          };
+        }
+        localReferences.push(resolved);
+      }
+    }
+
+    try {
+      const client = new JimengClient({ debug: false });
+
+      const result = await client.generateImage({
+        prompt,
+        req_key: model,
+        width,
+        height,
+        size,
+        region: "cn-north-1",
+        return_url: return_url ?? true,
+        image_urls: remoteReferences.length > 0 ? remoteReferences : undefined,
+        image_paths: localReferences.length > 0 ? localReferences : undefined,
+        force_single: false
+      });
+
+      if (!result.success || (!result.image_urls && !result.binary_data_base64)) {
+        const failureData = {
+          status: "error",
+          message: "图生图任务失败",
+          error: result.error || "未知错误",
+          task_id: result.task_id,
+          status_detail: result.status,
+          timestamp: new Date().toISOString()
+        };
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(failureData, null, 2)
+            }
+          ],
+          isError: true
+        };
+      }
+
+      const responseData = {
+        status: "success",
+        message: "图生图任务完成",
+        data: {
+          prompt,
+          model: model || 'jimeng_t2i_v40',
+          width,
+          height,
+          size,
+          remote_references: remoteReferences,
+          local_references: localReferences,
+          image_urls: result.image_urls,
+          binary_data_base64: result.binary_data_base64,
+          task_id: result.task_id,
+          status_detail: result.status
+        },
+        timestamp: new Date().toISOString()
+      };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(responseData, null, 2)
+          }
+        ]
+      };
+    } catch (error) {
+      const errorData = {
+        status: "error",
+        message: "图生图任务执行失败",
+        error: error instanceof Error ? error.message : String(error),
+        timestamp: new Date().toISOString()
+      };
+
       return {
         content: [
           {
@@ -322,8 +492,11 @@ server.tool(
         // 提交视频生成任务
         const result = await client.submitVideoTask({
           prompt: prompt,
-          req_key: "jimeng_vgfm_t2v_l20",
-          region: "cn-north-1"
+          req_key: "jimeng_vgfm_t2v_l22",
+          region: "cn-north-1",
+          duration: 8,
+          aspect_ratio: "16:9",
+          return_url: true
         });
         
         if (!result.success || !result.task_id) {
@@ -375,8 +548,12 @@ server.tool(
       
       const result = await client.generateVideo({
         prompt: prompt,
-        req_key: "jimeng_vgfm_t2v_l20",
-        region: "cn-north-1"
+        req_key: "jimeng_vgfm_t2v_l22",
+        region: "cn-north-1",
+        duration: 8,
+        aspect_ratio: "16:9",
+        return_url: true,
+        result_extra_body: { return_url: true }
       });
       
       if (!result.success || !result.video_urls || result.video_urls.length === 0) {
@@ -410,6 +587,7 @@ server.tool(
           prompt,
           video_urls: result.video_urls,
           video_url: result.video_urls[0],
+          video_base64_list: result.video_base64_list,
           task_id: result.task_id || ""
         },
         timestamp: new Date().toISOString()
@@ -497,8 +675,11 @@ server.tool(
       
       const result = await client.submitVideoTask({
         prompt: prompt,
-        req_key: "jimeng_vgfm_t2v_l20",
-        region: "cn-north-1"
+        req_key: "jimeng_vgfm_t2v_l22",
+        region: "cn-north-1",
+        duration: 8,
+        aspect_ratio: "16:9",
+        return_url: true
       });
       
       if (!result.success || !result.task_id) {
@@ -608,7 +789,9 @@ server.tool(
       // 查询任务结果
       log("查询视频生成任务结果...");
       
-      const result = await client.getVideoTaskResult(task_id, "jimeng_vgfm_t2v_l20");
+      const result = await client.getVideoTaskResult(task_id, "jimeng_vgfm_t2v_l22", {
+        extra_body: { return_url: true }
+      });
       
       if (!result.success) {
         log(`查询视频生成任务结果失败: ${result.error}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 import axios from 'axios';
 import crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const fsPromises = fs.promises;
 
 /**
  * 调试日志函数，确保所有日志只输出到 stderr
@@ -28,14 +32,36 @@ export interface JimengClientConfig {
 /**
  * 图像生成参数
  */
+export interface ImageLogoInfo {
+  add_logo?: boolean;
+  position?: number;
+  language?: number;
+  opacity?: number;
+  logo_text_content?: string;
+}
+
 export interface GenerateImageParams {
   prompt: string;
   negative_prompt?: string;
+  image_urls?: string[];
+  image_path?: string;
+  image_paths?: string[];
+  size?: number;
   width?: number;
   height?: number;
   return_url?: boolean;
   req_key?: string;
   region?: string;
+  scale?: number;
+  force_single?: boolean;
+  min_ratio?: number;
+  max_ratio?: number;
+  seed?: number;
+  logo_info?: ImageLogoInfo;
+  req_json?: Record<string, any> | string;
+  pollingIntervalMs?: number;
+  maxPollAttempts?: number;
+  auto_upload?: boolean;
 }
 
 /**
@@ -44,8 +70,48 @@ export interface GenerateImageParams {
 export interface GenerateImageResponse {
   success: boolean;
   image_urls?: string[];
+  binary_data_base64?: string[];
   error?: string;
   raw_response?: any;
+  task_id?: string;
+  status?: string;
+}
+
+/**
+ * 图像生成任务提交响应
+ */
+export interface ImageTaskSubmitResponse {
+  success: boolean;
+  task_id?: string;
+  error?: string;
+  raw_response?: any;
+}
+
+/**
+ * 图像生成任务结果响应
+ */
+export interface ImageTaskResultResponse {
+  success: boolean;
+  status?: string;
+  status_raw?: string;
+  image_urls?: string[];
+  binary_data_base64?: string[];
+  error?: string;
+  raw_response?: any;
+}
+
+export interface UploadImageParams {
+  paths: string[];
+  region?: string;
+  action?: string;
+  version?: string;
+}
+
+export interface UploadImageResponse {
+  success: boolean;
+  image_urls?: string[];
+  raw_response?: any;
+  error?: string;
 }
 
 /**
@@ -53,8 +119,30 @@ export interface GenerateImageResponse {
  */
 export interface GenerateVideoParams {
   prompt: string;  // 视频内容描述，必需参数
-  req_key?: string;  // 模型标识符，可选，默认为"jimeng_vgfm_t2v_l20"
+  req_key?: string;  // 模型标识符，可选，默认为"jimeng_vgfm_t2v_l22"
   region?: string;  // 区域，可选，默认为"cn-north-1"
+  negative_prompt?: string; // 反向提示词
+  duration?: number; // 视频时长，单位秒
+  video_num?: number; // 生成视频数量
+  frame_rate?: number; // 帧率
+  aspect_ratio?: string; // 长宽比
+  width?: number; // 指定宽度
+  height?: number; // 指定高度
+  resolution?: string; // 预设分辨率
+  cfg_scale?: number; // 文本引导系数
+  seed?: number; // 随机种子
+  motion_strength?: number; // 动作强度
+  music?: Record<string, any>; // 音乐配置
+  logo_info?: Record<string, any>; // 水印配置
+  return_url?: boolean; // 是否返回视频URL
+  return_video_base64?: boolean; // 是否返回视频base64
+  advanced_params?: Record<string, any>; // 透传更多参数
+  action?: string; // 自定义Action
+  version?: string; // 自定义Version
+  result_action?: string; // 查询任务Action
+  result_version?: string; // 查询任务Version
+  result_req_json?: string | Record<string, any>; // 查询任务附加req_json
+  result_extra_body?: Record<string, any>; // 查询任务附加参数
 }
 
 /**
@@ -74,6 +162,7 @@ export interface VideoTaskResultResponse {
   success: boolean;
   status?: string; // 任务状态：PENDING, RUNNING, SUCCEEDED, FAILED
   video_urls?: string[];
+  video_base64_list?: string[];
   error?: string;
   raw_response?: any;
 }
@@ -84,9 +173,11 @@ export interface VideoTaskResultResponse {
 export interface GenerateVideoResponse {
   success: boolean;
   video_urls?: string[];
+  video_base64_list?: string[];
   error?: string;
   raw_response?: any;
   task_id?: string;
+  status?: string;
 }
 
 /**
@@ -94,7 +185,7 @@ export interface GenerateVideoResponse {
  */
 export interface GenerateI2VParams {
   /**
-   * 模型标识符，默认为"jimeng_vgfm_i2v_l20"
+   * 模型标识符，默认为"jimeng_vgfm_i2v_l22"
    */
   req_key?: string;
   
@@ -112,6 +203,56 @@ export interface GenerateI2VParams {
    * 提示词，可选
    */
   prompt?: string;
+
+  /**
+   * 反向提示词，可选
+   */
+  negative_prompt?: string;
+
+  /**
+   * 输出视频数量，可选
+   */
+  video_num?: number;
+
+  /**
+   * 输出视频时长，单位秒
+   */
+  duration?: number;
+
+  /**
+   * 帧率设置
+   */
+  frame_rate?: number;
+
+  /**
+   * CFG Scale
+   */
+  cfg_scale?: number;
+
+  /**
+   * 随机种子
+   */
+  seed?: number;
+
+  /**
+   * 动作强度
+   */
+  motion_strength?: number;
+
+  /**
+   * 自定义音频配置
+   */
+  music?: Record<string, any>;
+
+  /**
+   * 水印配置
+   */
+  logo_info?: Record<string, any>;
+
+  /**
+   * 其他参数透传
+   */
+  advanced_params?: Record<string, any>;
   
   /**
    * 指定输出视频的长宽比，可选值："1:1", "4:3", "2:1", "3:2", "16:9"，默认 "16:9"
@@ -122,6 +263,36 @@ export interface GenerateI2VParams {
    * 区域，可选，默认为"cn-north-1"
    */
   region?: string;
+
+  /**
+   * 自定义Action
+   */
+  action?: string;
+
+  /**
+   * 自定义Version
+   */
+  version?: string;
+
+  /**
+   * 查询任务Action
+   */
+  result_action?: string;
+
+  /**
+   * 查询任务Version
+   */
+  result_version?: string;
+
+  /**
+   * 查询任务req_json
+   */
+  result_req_json?: string | Record<string, any>;
+
+  /**
+   * 查询任务附加参数
+   */
+  result_extra_body?: Record<string, any>;
 }
 
 /**
@@ -188,32 +359,67 @@ export class JimengClient {
   }
 
   /**
+   * 判断字符串是否为HTTP(S) URL
+   */
+  private isHttpUrl(value: string): boolean {
+    return /^https?:\/\//i.test(value);
+  }
+
+  /**
+   * 解析文件的MIME类型
+   */
+  private getMimeType(filePath: string): string {
+    const ext = path.extname(filePath).toLowerCase();
+    switch (ext) {
+      case '.jpg':
+      case '.jpeg':
+        return 'image/jpeg';
+      case '.png':
+        return 'image/png';
+      case '.webp':
+        return 'image/webp';
+      case '.bmp':
+        return 'image/bmp';
+      case '.gif':
+        return 'image/gif';
+      default:
+        return 'application/octet-stream';
+    }
+  }
+
+  /**
    * 火山引擎V4签名算法
    */
   private signV4Request(
     reqQuery: string,
-    reqBody: string,
-    region?: string,
+    reqBody: string | Buffer,
+    options?: {
+      region?: string;
+      method?: string;
+      contentType?: string;
+      headers?: Record<string, string>;
+    }
   ): { headers: Record<string, string>; requestUrl: string } {
     const t = new Date();
     const currentDate = t.toISOString().replace(/[:\-]|\.\d{3}/g, '');
     const datestamp = currentDate.substring(0, 8);
-    const usedRegion = region || this.region;
-    
-    const method = 'POST';
+    const usedRegion = options?.region || this.region;
+
+    const method = options?.method || 'POST';
     const canonicalUri = '/';
     const canonicalQuerystring = reqQuery;
     const signedHeaders = 'content-type;host;x-content-sha256;x-date';
-    const payloadHash = crypto.createHash('sha256').update(reqBody).digest('hex');
-    const contentType = 'application/json';
-    
+    const bodyBuffer = typeof reqBody === 'string' ? Buffer.from(reqBody) : reqBody;
+    const payloadHash = crypto.createHash('sha256').update(bodyBuffer).digest('hex');
+    const contentType = options?.contentType || 'application/json';
+
     const canonicalHeaders = [
       `content-type:${contentType}`,
       `host:${this.host}`,
       `x-content-sha256:${payloadHash}`,
       `x-date:${currentDate}`
     ].join('\n') + '\n';
-    
+
     const canonicalRequest = [
       method,
       canonicalUri,
@@ -249,13 +455,17 @@ export class JimengClient {
     
     const authorizationHeader = `${algorithm} Credential=${this.accessKey}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
     
-    const headers = {
+    const headers: Record<string, string> = {
       'X-Date': currentDate,
       'Authorization': authorizationHeader,
       'X-Content-Sha256': payloadHash,
       'Content-Type': contentType,
       'Host': this.host
     };
+
+    if (options?.headers) {
+      Object.assign(headers, options.headers);
+    }
     
     const requestUrl = `${this.endpoint}?${canonicalQuerystring}`;
     
@@ -263,135 +473,536 @@ export class JimengClient {
   }
 
   /**
-   * 生成图像
+   * 提交图像生成任务
    */
-  public async generateImage(params: GenerateImageParams): Promise<GenerateImageResponse> {
+  public async submitImageTask(params: GenerateImageParams): Promise<ImageTaskSubmitResponse> {
     let lastError: Error | null = null;
-    let retryCount = 0;
-    
-    while (retryCount <= this.retries) {
+    let attempt = 0;
+
+    while (attempt <= this.retries) {
       try {
-        // 验证必要的参数
         if (!params.prompt) {
           throw new Error('缺少必要的参数: prompt');
         }
-        
-        // 查询参数
+
         const queryParams = {
-          'Action': 'CVProcess',
+          'Action': 'CVSync2AsyncSubmitTask',
           'Version': '2022-08-31'
         };
         const formattedQuery = this.formatQuery(queryParams);
-        
-        // 请求体参数
-        const bodyParams = {
-          req_key: params.req_key || "jimeng_high_aes_general_v21_L",
-          prompt: params.prompt,
-          return_url: params.return_url !== undefined ? params.return_url : true,
-          width: params.width || 512,
-          height: params.height || 512,
-          negative_prompt: params.negative_prompt
+
+        const bodyParams: Record<string, any> = {
+          req_key: params.req_key || 'jimeng_t2i_v40',
+          prompt: params.prompt
         };
-        
-        // 移除undefined值
-        Object.keys(bodyParams).forEach(key => {
-          if (bodyParams[key as keyof typeof bodyParams] === undefined) {
-            delete bodyParams[key as keyof typeof bodyParams];
-          }
-        });
-        
-        const formattedBody = JSON.stringify(bodyParams);
-        
-        if (this.debug) {
-          debugLog('请求体:', formattedBody);
+
+        const allImageSources: string[] = [];
+        if (params.image_urls && params.image_urls.length > 0) {
+          allImageSources.push(...params.image_urls);
         }
-        
-        // 生成签名和请求头
+        if (params.image_path) {
+          allImageSources.push(params.image_path);
+        }
+        if (params.image_paths && params.image_paths.length > 0) {
+          allImageSources.push(...params.image_paths);
+        }
+
+        if (allImageSources.length > 0) {
+          const remoteUrls: string[] = [];
+          const localPaths: string[] = [];
+
+          for (const source of allImageSources) {
+            if (this.isHttpUrl(source)) {
+              remoteUrls.push(source);
+            } else {
+              const resolvedPath = path.isAbsolute(source) ? source : path.resolve(process.cwd(), source);
+              localPaths.push(resolvedPath);
+            }
+          }
+
+          if (localPaths.length > 0) {
+            if (params.auto_upload === false) {
+              throw new Error(`检测到本地图片路径，但 auto_upload 被禁用: ${localPaths.join(', ')}`);
+            }
+
+            const uploadResult = await this.uploadLocalImages({
+              paths: localPaths,
+              region: params.region
+            });
+
+            if (!uploadResult.success || !uploadResult.image_urls || uploadResult.image_urls.length === 0) {
+              throw new Error(uploadResult.error || '本地图片上传失败');
+            }
+
+            remoteUrls.push(...uploadResult.image_urls);
+          }
+
+          if (remoteUrls.length > 0) {
+            bodyParams.image_urls = remoteUrls;
+          }
+        }
+        if (params.size !== undefined) {
+          bodyParams.size = params.size;
+        }
+        if (params.width !== undefined) {
+          bodyParams.width = params.width;
+        }
+        if (params.height !== undefined) {
+          bodyParams.height = params.height;
+        }
+        if (params.scale !== undefined) {
+          bodyParams.scale = params.scale;
+        }
+        if (params.force_single !== undefined) {
+          bodyParams.force_single = params.force_single;
+        }
+        if (params.min_ratio !== undefined) {
+          bodyParams.min_ratio = params.min_ratio;
+        }
+        if (params.max_ratio !== undefined) {
+          bodyParams.max_ratio = params.max_ratio;
+        }
+        if (params.seed !== undefined) {
+          bodyParams.seed = params.seed;
+        }
+        if (params.negative_prompt !== undefined) {
+          bodyParams.negative_prompt = params.negative_prompt;
+        }
+
+        const formattedBody = JSON.stringify(bodyParams);
+
+        if (this.debug) {
+          debugLog('图像任务提交请求体:', formattedBody);
+        }
+
         const { headers, requestUrl } = this.signV4Request(
           formattedQuery,
           formattedBody,
-          params.region
+          {
+            region: params.region
+          }
         );
-        
+
         if (this.debug) {
-          debugLog('请求URL:', requestUrl);
-          debugLog('请求头:', JSON.stringify(headers, null, 2));
+          debugLog('图像任务提交请求URL:', requestUrl);
+          debugLog('图像任务提交请求头:', JSON.stringify(headers, null, 2));
         }
-        
-        // 发送请求
+
         const response = await axios.post(requestUrl, bodyParams, {
           headers: headers,
           timeout: this.timeout,
-          validateStatus: null // 允许任何状态码
+          validateStatus: null
         });
-        
+
         if (this.debug) {
-          debugLog('响应状态码:', response.status);
-          debugLog('响应头:', JSON.stringify(response.headers, null, 2));
-          debugLog('响应数据:', JSON.stringify(response.data, null, 2));
+          debugLog('图像任务提交响应状态码:', response.status);
+          debugLog('图像任务提交响应数据:', JSON.stringify(response.data, null, 2));
         }
-        
-        // 处理响应
+
         if (response.status !== 200) {
-          throw new Error(`HTTP错误! 状态码: ${response.status}`);
+          if (response.status === 429) {
+            throw new Error(`API并发限制错误: 请求过于频繁，请稍后再试。详细信息: ${JSON.stringify(response.data)}`);
+          }
+          throw new Error(`HTTP错误! 状态码: ${response.status}，详细信息: ${JSON.stringify(response.data)}`);
         }
-        
-        // 检查API错误
-        if (response.data.ResponseMetadata && response.data.ResponseMetadata.Error) {
-          const error = response.data.ResponseMetadata.Error;
-          throw new Error(`API错误: ${error.Message || '未知错误'}`);
+
+        const data = response.data;
+        if (data.code !== 10000) {
+          throw new Error(`API错误: ${data.message || '未知错误'} (错误码: ${data.code})`);
         }
-        
-        // 返回结果
-        if (response.data.data && response.data.data.image_urls && response.data.data.image_urls.length > 0) {
-          return {
-            success: true,
-            image_urls: response.data.data.image_urls,
-            raw_response: response.data
-          };
-        } else {
-          return {
-            success: false,
-            error: '未生成图像或响应格式不正确',
-            raw_response: response.data
-          };
+
+        const taskId = data.data?.task_id;
+        if (!taskId) {
+          throw new Error('API未返回任务ID');
         }
+
+        return {
+          success: true,
+          task_id: taskId,
+          raw_response: data
+        };
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
-        
+
         if (this.debug) {
-          debugLog(`尝试 #${retryCount + 1} 失败:`, lastError.message);
+          debugLog(`提交图像任务尝试 #${attempt + 1} 失败:`, lastError.message);
         }
-        
-        retryCount++;
-        
-        // 如果已经达到最大重试次数，返回错误
-        if (retryCount > this.retries) {
+
+        attempt++;
+
+        if (attempt > this.retries) {
           if (this.debug) {
-            debugLog(`已达到最大重试次数 (${this.retries})，放弃重试`);
+            debugLog(`已达到最大重试次数 (${this.retries})，放弃提交图像任务`);
           }
-          
+
           return {
             success: false,
             error: lastError.message
           };
         }
-        
-        // 指数退避策略
-        const waitTime = Math.min(1000 * Math.pow(2, retryCount - 1), 10000);
-        
+
+        const waitTime = Math.min(1000 * Math.pow(2, attempt - 1), 10000);
+
         if (this.debug) {
-          debugLog(`等待 ${waitTime}ms 后重试...`);
+          debugLog(`等待 ${waitTime}ms 后重试提交图像任务...`);
         }
-        
+
         await new Promise(resolve => setTimeout(resolve, waitTime));
       }
     }
-    
-    // 不应该运行到这里
+
     return {
       success: false,
       error: '未知错误'
+    };
+  }
+
+  /**
+   * 查询图像生成任务结果
+   */
+  public async getImageTaskResult(
+    taskId: string,
+    options: {
+      req_key?: string;
+      region?: string;
+      return_url?: boolean;
+      logo_info?: ImageLogoInfo;
+      req_json?: Record<string, any> | string;
+    } = {}
+  ): Promise<ImageTaskResultResponse> {
+    const queryParams = {
+      'Action': 'CVSync2AsyncGetResult',
+      'Version': '2022-08-31'
+    };
+    const formattedQuery = this.formatQuery(queryParams);
+
+    const reqKey = options.req_key || 'jimeng_t2i_v40';
+    let reqJsonValue: string | undefined;
+
+    if (options.req_json !== undefined) {
+      reqJsonValue = typeof options.req_json === 'string'
+        ? options.req_json
+        : JSON.stringify(options.req_json);
+    } else {
+      const returnUrl = options.return_url !== undefined ? options.return_url : true;
+      const reqJson: Record<string, any> = { return_url: returnUrl };
+
+      if (options.logo_info) {
+        reqJson.logo_info = options.logo_info;
+      }
+
+      reqJsonValue = JSON.stringify(reqJson);
+    }
+
+    const bodyParams: Record<string, any> = {
+      req_key: reqKey,
+      task_id: taskId
+    };
+
+    if (reqJsonValue) {
+      bodyParams.req_json = reqJsonValue;
+    }
+
+    const formattedBody = JSON.stringify(bodyParams);
+
+    if (this.debug) {
+      debugLog('查询图像任务结果请求体:', formattedBody);
+    }
+
+    const { headers, requestUrl } = this.signV4Request(
+      formattedQuery,
+      formattedBody,
+      {
+        region: options.region
+      }
+    );
+
+    if (this.debug) {
+      debugLog('查询图像任务结果请求URL:', requestUrl);
+      debugLog('查询图像任务结果请求头:', JSON.stringify(headers, null, 2));
+    }
+
+    const response = await axios({
+      url: requestUrl,
+      method: 'POST',
+      headers: headers,
+      data: formattedBody,
+      timeout: this.timeout,
+      validateStatus: null
+    });
+
+    if (this.debug) {
+      debugLog('查询图像任务结果响应状态码:', response.status);
+      debugLog('查询图像任务结果响应数据:', JSON.stringify(response.data, null, 2));
+    }
+
+    if (response.status !== 200) {
+      return {
+        success: false,
+        error: `HTTP错误! 状态码: ${response.status}`,
+        raw_response: response.data
+      };
+    }
+
+    const data = response.data;
+
+    if (data.code !== 10000) {
+      return {
+        success: false,
+        status: data.data?.status,
+        status_raw: data.data?.status,
+        error: `API错误: ${data.message || '未知错误'} (错误码: ${data.code})`,
+        raw_response: data
+      };
+    }
+
+    const taskData = data.data || {};
+    const statusRaw: string | undefined = taskData.status;
+
+    const normalizedStatus = (() => {
+      switch (statusRaw) {
+        case 'in_queue':
+          return 'IN_QUEUE';
+        case 'generating':
+        case 'processing':
+          return 'GENERATING';
+        case 'done':
+          return 'DONE';
+        case 'fail':
+          return 'FAILED';
+        case 'not_found':
+          return 'NOT_FOUND';
+        case 'expired':
+          return 'EXPIRED';
+        default:
+          return statusRaw ? statusRaw.toUpperCase() : undefined;
+      }
+    })();
+
+    return {
+      success: true,
+      status: normalizedStatus,
+      status_raw: statusRaw,
+      image_urls: taskData.image_urls || undefined,
+      binary_data_base64: taskData.binary_data_base64 || undefined,
+      raw_response: data
+    };
+  }
+
+  /**
+   * 上传本地图片以获取可访问的URL
+   */
+  public async uploadLocalImages(params: UploadImageParams): Promise<UploadImageResponse> {
+    if (!params.paths || params.paths.length === 0) {
+      return { success: false, error: '至少提供一个本地图片路径' };
+    }
+
+    try {
+      const files = await Promise.all(params.paths.map(async (inputPath) => {
+        const absolutePath = path.isAbsolute(inputPath) ? inputPath : path.resolve(process.cwd(), inputPath);
+
+        const stats = await fsPromises.stat(absolutePath);
+        if (!stats.isFile()) {
+          throw new Error(`路径不是文件: ${absolutePath}`);
+        }
+
+        const buffer = await fsPromises.readFile(absolutePath);
+        const filename = path.basename(absolutePath);
+        const contentType = this.getMimeType(absolutePath);
+
+        return { filename, buffer, contentType };
+      }));
+
+      const boundary = `----JimengFormBoundary${crypto.randomBytes(8).toString('hex')}`;
+      const CRLF = '\r\n';
+      const fieldName = 'image_file';
+
+      const parts: Buffer[] = [];
+      for (const file of files) {
+        parts.push(Buffer.from(`--${boundary}${CRLF}`));
+        parts.push(Buffer.from(`Content-Disposition: form-data; name="${fieldName}"; filename="${file.filename}"${CRLF}`));
+        parts.push(Buffer.from(`Content-Type: ${file.contentType}${CRLF}${CRLF}`));
+        parts.push(file.buffer);
+        parts.push(Buffer.from(CRLF));
+      }
+      parts.push(Buffer.from(`--${boundary}--${CRLF}`));
+
+      const requestBody = Buffer.concat(parts);
+
+      const queryParams = {
+        Action: params.action || 'CVUploadImages',
+        Version: params.version || '2022-08-31'
+      };
+      const formattedQuery = this.formatQuery(queryParams);
+
+      const contentTypeHeader = `multipart/form-data; boundary=${boundary}`;
+      const { headers, requestUrl } = this.signV4Request(
+        formattedQuery,
+        requestBody,
+        {
+          region: params.region,
+          contentType: contentTypeHeader
+        }
+      );
+
+      headers['Content-Length'] = requestBody.length.toString();
+
+      if (this.debug) {
+        debugLog('上传图片请求URL:', requestUrl);
+        debugLog('上传图片请求头:', JSON.stringify(headers, null, 2));
+      }
+
+      const response = await axios.post(requestUrl, requestBody, {
+        headers,
+        timeout: this.timeout,
+        validateStatus: null
+      });
+
+      if (this.debug) {
+        debugLog('上传图片响应状态码:', response.status);
+        debugLog('上传图片响应数据:', JSON.stringify(response.data, null, 2));
+      }
+
+      if (response.status !== 200) {
+        return {
+          success: false,
+          error: `HTTP错误! 状态码: ${response.status}`,
+          raw_response: response.data
+        };
+      }
+
+      const data = response.data;
+      const imageUrls = data?.data?.image_urls || data?.result?.image_urls || data?.image_urls;
+
+      if (Array.isArray(imageUrls) && imageUrls.length > 0) {
+        return {
+          success: true,
+          image_urls: imageUrls,
+          raw_response: data
+        };
+      }
+
+      return {
+        success: false,
+        error: '上传成功但未返回图片URL',
+        raw_response: data
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        error: message
+      };
+    }
+  }
+
+  /**
+   * 生成图像
+   */
+  public async generateImage(params: GenerateImageParams): Promise<GenerateImageResponse> {
+    const submitResult = await this.submitImageTask(params);
+
+    if (!submitResult.success || !submitResult.task_id) {
+      return {
+        success: false,
+        error: submitResult.error || '提交图像生成任务失败',
+        raw_response: submitResult.raw_response
+      };
+    }
+
+    const taskId = submitResult.task_id;
+    const pollingInterval = params.pollingIntervalMs ?? 5000;
+    const maxAttempts = params.maxPollAttempts ?? 60;
+
+    if (this.debug) {
+      debugLog(`图像任务提交成功，任务ID: ${taskId}`);
+      debugLog(`开始轮询图像任务结果，最多尝试 ${maxAttempts} 次，每次间隔 ${pollingInterval}ms`);
+    }
+
+    let lastResult: ImageTaskResultResponse | null = null;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (this.debug) {
+        debugLog(`查询图像任务结果 (${attempt + 1}/${maxAttempts})...`);
+      }
+
+      lastResult = await this.getImageTaskResult(taskId, {
+        req_key: params.req_key,
+        region: params.region,
+        return_url: params.return_url,
+        logo_info: params.logo_info,
+        req_json: params.req_json
+      });
+
+      if (!lastResult.success) {
+        if (this.debug) {
+          debugLog('查询图像任务结果失败:', lastResult.error || '未知错误');
+        }
+
+        return {
+          success: false,
+          error: lastResult.error || '查询图像生成任务失败',
+          raw_response: lastResult.raw_response,
+          task_id: taskId,
+          status: lastResult.status
+        };
+      }
+
+      if (lastResult.status === 'DONE' || lastResult.status === 'SUCCEEDED') {
+        if (lastResult.image_urls && lastResult.image_urls.length > 0) {
+          return {
+            success: true,
+            image_urls: lastResult.image_urls,
+            binary_data_base64: lastResult.binary_data_base64,
+            raw_response: lastResult.raw_response,
+            task_id: taskId,
+            status: lastResult.status
+          };
+        }
+
+        if (lastResult.binary_data_base64 && lastResult.binary_data_base64.length > 0) {
+          return {
+            success: true,
+            binary_data_base64: lastResult.binary_data_base64,
+            raw_response: lastResult.raw_response,
+            task_id: taskId,
+            status: lastResult.status
+          };
+        }
+
+        return {
+          success: false,
+          error: '任务完成但未返回图像数据',
+          raw_response: lastResult.raw_response,
+          task_id: taskId,
+          status: lastResult.status
+        };
+      }
+
+      if (lastResult.status === 'FAILED' || lastResult.status === 'NOT_FOUND' || lastResult.status === 'EXPIRED') {
+        return {
+          success: false,
+          error: lastResult.error || `图像生成任务失败，状态: ${lastResult.status}`,
+          raw_response: lastResult.raw_response,
+          task_id: taskId,
+          status: lastResult.status
+        };
+      }
+
+      if (attempt < maxAttempts - 1) {
+        if (this.debug) {
+          debugLog(`任务状态: ${lastResult.status || '未知'}，等待 ${pollingInterval}ms 后继续查询...`);
+        }
+        await new Promise(resolve => setTimeout(resolve, pollingInterval));
+      }
+    }
+
+    return {
+      success: false,
+      error: '轮询任务结果超时，请使用任务ID手动查询结果',
+      task_id: taskId,
+      status: lastResult?.status,
+      raw_response: lastResult?.raw_response
     };
   }
 
@@ -411,18 +1022,70 @@ export class JimengClient {
         }
         
         // 查询参数 - 使用异步提交任务API
+        const action = params.action || 'CVSync2AsyncSubmitTask';
+        const version = params.version || '2022-08-31';
+
         const queryParams = {
-          'Action': 'CVSync2AsyncSubmitTask',
-          'Version': '2022-08-31'
+          'Action': action,
+          'Version': version
         };
         const formattedQuery = this.formatQuery(queryParams);
-        
+
         // 请求体参数
-        const bodyParams = {
-          req_key: params.req_key || "jimeng_vgfm_t2v_l20",
+        const bodyParams: Record<string, any> = {
+          req_key: params.req_key || "jimeng_vgfm_t2v_l22",
           prompt: params.prompt
         };
-        
+
+        if (params.negative_prompt !== undefined) {
+          bodyParams.negative_prompt = params.negative_prompt;
+        }
+        if (params.duration !== undefined) {
+          bodyParams.duration = params.duration;
+        }
+        if (params.video_num !== undefined) {
+          bodyParams.video_num = params.video_num;
+        }
+        if (params.frame_rate !== undefined) {
+          bodyParams.frame_rate = params.frame_rate;
+        }
+        if (params.aspect_ratio !== undefined) {
+          bodyParams.aspect_ratio = params.aspect_ratio;
+        }
+        if (params.width !== undefined) {
+          bodyParams.width = params.width;
+        }
+        if (params.height !== undefined) {
+          bodyParams.height = params.height;
+        }
+        if (params.resolution !== undefined) {
+          bodyParams.resolution = params.resolution;
+        }
+        if (params.cfg_scale !== undefined) {
+          bodyParams.cfg_scale = params.cfg_scale;
+        }
+        if (params.seed !== undefined) {
+          bodyParams.seed = params.seed;
+        }
+        if (params.motion_strength !== undefined) {
+          bodyParams.motion_strength = params.motion_strength;
+        }
+        if (params.music !== undefined) {
+          bodyParams.music = params.music;
+        }
+        if (params.logo_info !== undefined) {
+          bodyParams.logo_info = params.logo_info;
+        }
+        if (params.return_url !== undefined) {
+          bodyParams.return_url = params.return_url;
+        }
+        if (params.return_video_base64 !== undefined) {
+          bodyParams.return_video_base64 = params.return_video_base64;
+        }
+        if (params.advanced_params) {
+          Object.assign(bodyParams, params.advanced_params);
+        }
+
         const formattedBody = JSON.stringify(bodyParams);
         
         // 总是开启调试信息以便排查问题
@@ -432,7 +1095,9 @@ export class JimengClient {
         const { headers, requestUrl } = this.signV4Request(
           formattedQuery,
           formattedBody,
-          params.region
+          {
+            region: params.region
+          }
         );
         
         // 打印请求信息以便调试
@@ -528,7 +1193,17 @@ export class JimengClient {
   /**
    * 查询视频生成任务结果
    */
-  public async getVideoTaskResult(taskId: string, reqKey: string = "jimeng_vgfm_t2v_l20"): Promise<VideoTaskResultResponse> {
+  public async getVideoTaskResult(
+    taskId: string,
+    reqKey: string = "jimeng_vgfm_t2v_l22",
+    options: {
+      region?: string;
+      action?: string;
+      version?: string;
+      req_json?: string | Record<string, any>;
+      extra_body?: Record<string, any>;
+    } = {}
+  ): Promise<VideoTaskResultResponse> {
     let lastError: Error | null = null;
     const retries = 1;  // 只重试一次
     let retryCount = 0;
@@ -536,17 +1211,30 @@ export class JimengClient {
     while (retryCount <= retries) {
       try {
         // 查询参数 - 使用查询结果API
+        const action = options.action || 'CVSync2AsyncGetResult';
+        const version = options.version || '2022-08-31';
+
         const queryParams = {
-          'Action': 'CVSync2AsyncGetResult',
-          'Version': '2022-08-31'
+          'Action': action,
+          'Version': version
         };
         const formattedQuery = this.formatQuery(queryParams);
-        
+
         // 请求体参数
-        const bodyParams = {
+        const bodyParams: Record<string, any> = {
           req_key: reqKey,
           task_id: taskId
         };
+
+        if (options.req_json !== undefined) {
+          bodyParams.req_json = typeof options.req_json === 'string'
+            ? options.req_json
+            : JSON.stringify(options.req_json);
+        }
+
+        if (options.extra_body) {
+          Object.assign(bodyParams, options.extra_body);
+        }
         
         const formattedBody = JSON.stringify(bodyParams);
         
@@ -557,7 +1245,9 @@ export class JimengClient {
         const { headers, requestUrl } = this.signV4Request(
           formattedQuery,
           formattedBody,
-          reqKey.split('_')[2] // 提取region
+          {
+            region: options.region
+          }
         );
         
         // 开启调试信息
@@ -620,9 +1310,10 @@ export class JimengClient {
               normalizedStatus = taskStatus.toUpperCase();
           }
           
-          // 解析视频URL - 从两个可能的位置获取
+          // 解析视频URL和Base64数据
           let videoUrls: string[] = [];
-          
+          let videoBase64List: string[] = [];
+
           // 1. 从resp_data中解析视频URLs（需要先将字符串解析为JSON对象）
           if (taskData.resp_data && typeof taskData.resp_data === 'string') {
             try {
@@ -630,23 +1321,61 @@ export class JimengClient {
               if (respData.urls && Array.isArray(respData.urls)) {
                 videoUrls = respData.urls;
               }
+              if (respData.video_urls && Array.isArray(respData.video_urls)) {
+                videoUrls = videoUrls.concat(respData.video_urls);
+              }
+              if (respData.binary_data_base64 && Array.isArray(respData.binary_data_base64)) {
+                videoBase64List = videoBase64List.concat(respData.binary_data_base64);
+              }
+              if (respData.video_base64_list && Array.isArray(respData.video_base64_list)) {
+                videoBase64List = videoBase64List.concat(respData.video_base64_list);
+              }
+              if (respData.base64_list && Array.isArray(respData.base64_list)) {
+                videoBase64List = videoBase64List.concat(respData.base64_list);
+              }
             } catch (e) {
               debugLog('解析resp_data时出错:', e);
             }
           }
-          
+
           // 2. 如果存在video_url字段，添加到videoUrls
           if (taskData.video_url && typeof taskData.video_url === 'string') {
             videoUrls.push(taskData.video_url);
           }
-          
-          // 返回任务状态和视频URL
-          return {
+
+          if (Array.isArray(taskData.video_urls)) {
+            videoUrls = videoUrls.concat(taskData.video_urls);
+          }
+
+          if (Array.isArray(taskData.video_base64_list)) {
+            videoBase64List = videoBase64List.concat(taskData.video_base64_list);
+          }
+
+          if (Array.isArray(taskData.binary_data_base64)) {
+            videoBase64List = videoBase64List.concat(taskData.binary_data_base64);
+          }
+
+          const uniqueVideoUrls = videoUrls.filter(Boolean).length > 0
+            ? Array.from(new Set(videoUrls.filter(Boolean)))
+            : [];
+
+          const uniqueVideoBase64 = videoBase64List.filter(Boolean).length > 0
+            ? Array.from(new Set(videoBase64List.filter(Boolean)))
+            : [];
+
+          const responsePayload: VideoTaskResultResponse = {
             success: true,
             status: normalizedStatus,
-            video_urls: videoUrls,
+            video_urls: uniqueVideoUrls,
             raw_response: data
           };
+
+          if (uniqueVideoBase64.length > 0) {
+            responsePayload.video_base64_list = uniqueVideoBase64;
+          }
+
+          // 返回任务状态和视频数据
+          return responsePayload;
         } else {
           throw new Error(`HTTP错误! 状态码: ${response.status}，详细信息: ${JSON.stringify(response.data)}`);
         }
@@ -714,8 +1443,18 @@ export class JimengClient {
       debugLog(`轮询任务结果 (${i+1}/${maxAttempts})...`);
       
       // 查询任务结果
-      const result = await this.getVideoTaskResult(taskResult.task_id, params.req_key);
-      
+      const result = await this.getVideoTaskResult(
+        taskResult.task_id,
+        params.req_key || 'jimeng_vgfm_t2v_l22',
+        {
+          region: params.region,
+          action: params.result_action,
+          version: params.result_version,
+          req_json: params.result_req_json,
+          extra_body: params.result_extra_body
+        }
+      );
+
       if (result.success) {
         // 根据任务状态处理
         if ((result.status === 'SUCCEEDED' || result.status === 'done') && result.video_urls && result.video_urls.length > 0) {
@@ -723,15 +1462,18 @@ export class JimengClient {
           return {
             success: true,
             video_urls: result.video_urls,
+            video_base64_list: result.video_base64_list,
             raw_response: result.raw_response,
-            task_id: taskResult.task_id
+            task_id: taskResult.task_id,
+            status: result.status
           };
         } else if (result.status === 'FAILED') {
           return {
             success: false,
             error: '视频生成任务失败',
             raw_response: result.raw_response,
-            task_id: taskResult.task_id
+            task_id: taskResult.task_id,
+            status: result.status
           };
         } else if (result.status === 'PENDING' || result.status === 'RUNNING') {
           debugLog(`任务仍在进行中，状态: ${result.status}，等待 ${pollingInterval/1000} 秒后重试...`);
@@ -777,22 +1519,56 @@ export class JimengClient {
         }
         
         // 查询参数 - 使用异步提交任务API
+        const action = params.action || 'CVSync2AsyncSubmitTask';
+        const version = params.version || '2022-08-31';
+
         const queryParams = {
-          'Action': 'CVSync2AsyncSubmitTask',
-          'Version': '2022-08-31'
+          'Action': action,
+          'Version': version
         };
         const formattedQuery = this.formatQuery(queryParams);
-        
+
         // 请求体参数 - 默认使用图生视频模型
-        const bodyParams = {
-          req_key: params.req_key || "jimeng_vgfm_i2v_l20",
+        const bodyParams: Record<string, any> = {
+          req_key: params.req_key || "jimeng_vgfm_i2v_l22",
           image_urls: imageUrls,
           // 必须指定aspect_ratio参数，不能使用keep_ratio
           aspect_ratio: params.aspect_ratio || "16:9",
           // 如果有提示词则添加
           ...(params.prompt ? { prompt: params.prompt } : {})
         };
-        
+
+        if (params.negative_prompt !== undefined) {
+          bodyParams.negative_prompt = params.negative_prompt;
+        }
+        if (params.video_num !== undefined) {
+          bodyParams.video_num = params.video_num;
+        }
+        if (params.duration !== undefined) {
+          bodyParams.duration = params.duration;
+        }
+        if (params.frame_rate !== undefined) {
+          bodyParams.frame_rate = params.frame_rate;
+        }
+        if (params.cfg_scale !== undefined) {
+          bodyParams.cfg_scale = params.cfg_scale;
+        }
+        if (params.seed !== undefined) {
+          bodyParams.seed = params.seed;
+        }
+        if (params.motion_strength !== undefined) {
+          bodyParams.motion_strength = params.motion_strength;
+        }
+        if (params.music !== undefined) {
+          bodyParams.music = params.music;
+        }
+        if (params.logo_info !== undefined) {
+          bodyParams.logo_info = params.logo_info;
+        }
+        if (params.advanced_params) {
+          Object.assign(bodyParams, params.advanced_params);
+        }
+
         const formattedBody = JSON.stringify(bodyParams);
         
         // 调试信息
@@ -802,7 +1578,9 @@ export class JimengClient {
         const { headers, requestUrl } = this.signV4Request(
           formattedQuery,
           formattedBody,
-          params.region
+          {
+            region: params.region
+          }
         );
         
         // 调试信息
@@ -907,7 +1685,17 @@ export class JimengClient {
       debugLog(`轮询任务结果 (${i+1}/${maxAttempts})...`);
       
       // 查询任务结果
-      const result = await this.getVideoTaskResult(taskResult.task_id, params.req_key || "jimeng_vgfm_i2v_l20");
+      const result = await this.getVideoTaskResult(
+        taskResult.task_id,
+        params.req_key || "jimeng_vgfm_i2v_l22",
+        {
+          region: params.region,
+          action: params.result_action,
+          version: params.result_version,
+          req_json: params.result_req_json,
+          extra_body: params.result_extra_body
+        }
+      );
       
       if (result.success) {
         // 根据任务状态处理
@@ -916,15 +1704,18 @@ export class JimengClient {
           return {
             success: true,
             video_urls: result.video_urls,
+            video_base64_list: result.video_base64_list,
             raw_response: result.raw_response,
-            task_id: taskResult.task_id
+            task_id: taskResult.task_id,
+            status: result.status
           };
         } else if (result.status === 'FAILED') {
           return {
             success: false,
             error: '视频生成任务失败',
             raw_response: result.raw_response,
-            task_id: taskResult.task_id
+            task_id: taskResult.task_id,
+            status: result.status
           };
         } else if (result.status === 'PENDING' || result.status === 'RUNNING' || result.status === 'in_queue') {
           debugLog(`任务仍在进行中，状态: ${result.status}，等待 ${pollingInterval/1000} 秒后重试...`);


### PR DESCRIPTION
## Summary
- allow text-to-image workflows to override the req_key across the client, CLI, and MCP tooling while documenting the new option
- add automatic uploading for local reference images with generateImage now accepting image_paths/image_path alongside the new jimeng-image-to-image CLI example
- expose an image-to-image MCP tool and README guidance covering local file support and the dedicated CLI flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfb66485588329981dc1088f96b5ec